### PR TITLE
Using HashMap instead of WeakHashMap to keep all observables

### DIFF
--- a/src/main/java/pl/touk/tscreload/impl/Observable.java
+++ b/src/main/java/pl/touk/tscreload/impl/Observable.java
@@ -17,11 +17,11 @@ package pl.touk.tscreload.impl;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.HashMap;
 
 public abstract class Observable<T> {
 
-    private final Set<Observer<T>> observers = Collections.newSetFromMap(new WeakHashMap<>());
+    private final Set<Observer<T>> observers = Collections.newSetFromMap(new HashMap<>());
 
     public void addWeakObserver(Observer<T> observer) {
         synchronized (observers) {


### PR DESCRIPTION
This is required because the garbage collector can remove entries from a WeakHashMap, causing the library not to notify observables.